### PR TITLE
Require remote argument in scripts/docker_sync.sh

### DIFF
--- a/scripts/docker_sync.sh
+++ b/scripts/docker_sync.sh
@@ -6,8 +6,9 @@ if [ ! -f docker-compose.yml ]; then
   exit 1
 fi
 
+REMOTE="$1"
 if [ -z "$REMOTE" ]; then
-  echo "Error: remote host required (e.g. 10.0.0.5:7411)"
+  echo "Usage: $0 <remote> (e.g. 10.0.0.5:7411)"
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation
- Make `scripts/docker_sync.sh` require the remote host as a positional argument because the sync command cannot run without it and using an environment override was inconsistent.

### Description
- Read `REMOTE` from the first positional parameter via `REMOTE="$1"` and replace the previous environment check with a usage message `Usage: $0 <remote> (e.g. 10.0.0.5:7411)`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d44b1aae8832f87765de1fc41ce17)